### PR TITLE
feature #163730056 A user has dashboard with scheduled meetup

### DIFF
--- a/UI/admin-dashboard.html
+++ b/UI/admin-dashboard.html
@@ -37,12 +37,12 @@
           <div class="dashboard-content__sidebar">
             <ul class="sidebar__item">
               <li class="sidebar__item__list">
-                <h4 class="sidebar__item__list__heading">Total Posted question(s)</h4>
-                <span class="sidebar__item__list__value">20</span>
+                <h4 class="sidebar__item__list__heading">Total Created meetups(s)</h4>
+                <span class="sidebar__item__list__value">0</span>
               </li>
               <li class="sidebar__item__list">
-                <h4 class="sidebar__item__list__heading">Total Commented Question(s)</h4>
-                <span class="sidebar__item__list__value">60</span>
+                <h4 class="sidebar__item__list__heading">Total user(s)</h4>
+                <span class="sidebar__item__list__value">0</span>
               </li>
             </ul>
 

--- a/UI/js/admin.js
+++ b/UI/js/admin.js
@@ -38,10 +38,6 @@ const checkExpiredToken = (responseBody) => {
   }
 };
 
-
-// const meetupImageElement = document.getElementById('meetup-images');
-// meetupImageElement.addEventListener('change', handleImageUpload);
-
 /**
  * Display user feedback
  *
@@ -169,7 +165,11 @@ const createMeetup = async (e) => {
         });
       }
     })
-    .catch(err => err);
+    .catch((err) => {
+      if (err) {
+        window.location.href = 'admin-dashboard.html';
+      }
+    });
 };
 
 // Get sign up button

--- a/UI/js/user-dashboard.js
+++ b/UI/js/user-dashboard.js
@@ -12,3 +12,171 @@ if (localStorage.getItem('user')) {
 } else {
   window.location.href = 'sign-in.html';
 }
+
+// get user token
+let userToken = '';
+if (localStorage.getItem('user')) {
+  const userData = JSON.parse(localStorage.getItem('user'));
+  const {
+    token,
+  } = userData;
+
+  userToken = token;
+}
+
+const showOverlay = () => {
+  document.querySelector('.overlay').style.display = 'block';
+};
+
+const hideOverlay = () => {
+  document.querySelector('.overlay').style.display = 'none';
+};
+
+// check if token has expired
+const checkExpiredToken = (responseBody) => {
+  if (responseBody.error.expiredAt) {
+    // Redirect user to home page
+    setTimeout(() => {
+      window.location.href = 'sign-in.html';
+    }, 1000);
+  }
+};
+
+/**
+ * Display user feedback
+ *
+ * @param {object} responseData
+ *
+ * @returns {string} listItem
+ */
+const displayFeedback = (responseData) => {
+  let listItem = '';
+
+  if (responseData.status === 400 && typeof responseData.error !== 'string') {
+    if (responseData.error.expiredAt) {
+      listItem += '<li class=\'feedback-list-item\'>Session expired, Please Login.</li>';
+    } else {
+      listItem += '<li class=\'feedback-list-item\'>Please fill the required field below.</li>';
+    }
+  } else if (responseData.status === 200) {
+    listItem += '<li class=\'feedback-list-item\'>upcoming meetup scheduled found</li>';
+  } else {
+    listItem += `<li class='feedback-list-item'>${responseData.error}</li>`;
+  }
+
+  return listItem;
+};
+
+/**
+ * Get total number of posted questions by user
+ */
+const getTotalPostedQuestions = () => {
+  // questions/user endpoint url
+  const url = 'https://meet-up-questioner.herokuapp.com/api/v1/questions/user';
+
+  // make a GET request to questions/user
+  fetch(url, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      token: userToken,
+    },
+  })
+    .then(res => res.json())
+    .then((body) => {
+      if (body.status === 200) {
+        // get sidebar element container (span.total-questions)
+        const totalQuestionsContainer = document.querySelector('.total-questions');
+
+        // Display total number of posted questions
+        totalQuestionsContainer.innerHTML = body.data[0].count;
+      }
+    })
+    .catch(err => err);
+};
+
+/**
+ * Get total number of posted questions by user
+ */
+const getTotalCommentedQuestions = () => {
+  // comments/user endpoint url
+  const url = 'https://meet-up-questioner.herokuapp.com/api/v1/comments/user';
+
+  // make a GET request to comments/user
+  fetch(url, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      token: userToken,
+    },
+  })
+    .then(res => res.json())
+    .then((body) => {
+      if (body.status === 200) {
+        // get sidebar element container (span.total-comments)
+        const totalCommentsContainer = document.querySelector('.total-comments');
+
+        // Display total number of commented question
+        totalCommentsContainer.innerHTML = body.data[0].count;
+      }
+    })
+    .catch(err => err);
+};
+
+/**
+ * Fetch and populate user table with scheduled upcoming meetup details
+ */
+const getAllRsvps = () => {
+  showOverlay();
+  getTotalPostedQuestions();
+  getTotalCommentedQuestions();
+  // meetup rsvp endpoint url
+  const url = 'https://meet-up-questioner.herokuapp.com/api/v1/meetups/rsvps';
+
+  // make a GET request to meetups/rsvps
+  fetch(url, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      token: userToken,
+    },
+  })
+    .then(res => res.json())
+    .then((body) => {
+      hideOverlay();
+      const feedbackContainer = document.querySelector('.feedback-message');
+
+      if (body.status === 200) {
+        let output = '';
+        body.data.forEach((meetup) => {
+          const formatedDate = moment(meetup.happeningon).format('dddd, MMMM Do YYYY, h:mm:ss a');
+          output += `<tr>
+                        <td>${meetup.topic}</td>
+                        <td>${meetup.location}</td>
+                        <td>${formatedDate}</td>
+                      </tr>`;
+        });
+
+        // remove error if any
+        feedbackContainer.classList.remove('feedback-message-error');
+
+        // get meetup rsvps table body
+        const tableBody = document.querySelector('.table-body');
+
+        // Display all meetup rsvps record
+        tableBody.innerHTML = output;
+      } else {
+        feedbackContainer.innerHTML = displayFeedback(body);
+        feedbackContainer.classList.add('feedback-message-error');
+
+        // redirect to login if token has expired
+        checkExpiredToken(body);
+      }
+    })
+    .catch((err) => {
+      if (err) {
+        window.location.href = 'user-dashboard.html';
+      }
+    });
+};
+getAllRsvps();

--- a/UI/user-dashboard.html
+++ b/UI/user-dashboard.html
@@ -39,11 +39,11 @@
             <ul class="sidebar__item">
               <li class="sidebar__item__list">
                 <h4 class="sidebar__item__list__heading">Total Posted Question(s)</h4>
-                <span class="sidebar__item__list__value">20</span>
+                <span class="sidebar__item__list__value total-questions">0</span>
               </li>
               <li class="sidebar__item__list">
-                <h4 class="sidebar__item__list__heading">Total Commented Question(s)</h4>
-                <span class="sidebar__item__list__value">60</span>
+                <h4 class="sidebar__item__list__heading">Total Comment(s)</h4>
+                <span class="sidebar__item__list__value total-comments">0</span>
               </li>
             </ul>
           </div>
@@ -54,6 +54,10 @@
               <h3 class="card-header">Scheduled Upcoming Meetup</h3>
               <!--/.card-header-->
 
+              <ul class="feedback-message">
+
+              </ul>
+
               <div class="card-body">
                 <div class="table-container">
                   <table class="table">
@@ -62,35 +66,11 @@
                         <th>Meetup Topic</th>
                         <th>Location</th>
                         <th>Date</th>
-                        <th>Tags</th>
                       </tr>
                     </thead>
 
                     <tbody class="table-body">
-                      <tr>
-                        <td>Why learn Go in 2019?</td>
-                        <td>Abuja</td>
-                        <td>Tuesday, January 1st 2019, 2:30:00 pm</td>
-                        <td>web, programing</td>
-                      </tr>
-                      <tr>
-                        <td>Why learn JAVA in 2019?</td>
-                        <td>Lagos</td>
-                        <td>Tuesday, January 1st 2019, 2:30:00 pm</td>
-                        <td>web, programing</td>
-                      </tr>
-                      <tr>
-                        <td>Why learn Restful API</td>
-                        <td>Lagos</td>
-                        <td>Tuesday, January 1st 2019, 2:30:00 pm</td>
-                        <td>web, programing</td>
-                      </tr>
-                      <tr>
-                        <td>Why learn Node in 2019?</td>
-                        <td>Kano</td>
-                        <td>Tuesday, January 1st 2019, 2:30:00 pm</td>
-                        <td>web, programing</td>
-                      </tr>
+
                     </tbody>
 
                   </table>
@@ -118,6 +98,17 @@
             </div>
           </div>
           <!--/.dashboard-content__main__content-->
+
+          <div class="overlay">
+            <div class="spinner-icon-container">
+              <svg version="1.2" class="spinner-icon" height="80" width="125" xmlns="http://www.w3.org/2000/svg"
+                viewport="0 0 125 80" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <path fill="none" stroke="#ffffff" stroke-miterlimit="20" d="M52,21 L81,40 L52,60 Z"></path>
+              </svg>
+            </div>
+          </div>
+          <!--/.overlay-->
+
         </div>
         <!--/.dashboard__content-->
       </div>
@@ -145,6 +136,7 @@
   </section>
   <!--/.footer-->
 
+  <script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.17.1/moment.min.js"></script>
   <script src="js/user-dashboard.js"></script>
 </body>
 

--- a/app/controllers/CommentController.js
+++ b/app/controllers/CommentController.js
@@ -81,6 +81,32 @@ class CommentController {
       });
     }
   }
+
+  /**
+   * Get total number of commented questions by user id
+   *
+   * @param {*} req
+   * @param {*} res
+   */
+  static async getCommentByUserId(req, res) {
+    try {
+      const queryString = 'SELECT COUNT(*) FROM comments WHERE comments.userid = $1';
+
+      const {
+        rows,
+      } = await db.query(queryString, [req.user.id]);
+
+      return res.status(200).json({
+        status: 200,
+        data: rows,
+      });
+    } catch (error) {
+      return res.status(400).json({
+        status: 400,
+        error: 'Something went wrong, try again',
+      });
+    }
+  }
 }
 
 export default CommentController;

--- a/app/controllers/MeetupController.js
+++ b/app/controllers/MeetupController.js
@@ -110,6 +110,44 @@ class MeetupController {
   }
 
   /**
+   * get all users scheduled upcoming meetup
+   *
+   * @param {*} req
+   * @param {*} res
+   */
+  static async getAllRsvps(req, res) {
+    try {
+      // Get a single meet up record
+      const queryString = 'SELECT meetups.topic, meetups.location, meetups.happeningon, meetups.tags FROM meetups LEFT JOIN rsvps ON meetups.id = rsvps.meetupid WHERE rsvps.userid = $1 AND rsvps.response = $2 AND meetups.happeningOn >= $3 ORDER BY happeningon DESC';
+
+      // get current date-time in iso format
+      const today = new Date(moment()).toISOString();
+
+      const {
+        rows,
+      } = await db.query(queryString, [req.user.id, 'yes', today]);
+
+      if (!rows[0]) {
+        return res.status(404).json({
+          status: 404,
+          error: 'No scheduled upcoming meetup found',
+        });
+      }
+
+      // On success
+      return res.status(200).json({
+        status: 200,
+        data: rows,
+      });
+    } catch (errors) {
+      return res.status(404).json({
+        status: 404,
+        error: 'Something went wrong, try again',
+      });
+    }
+  }
+
+  /**
    *
    * Get specific meet up record
    *
@@ -232,6 +270,12 @@ class MeetupController {
     }
   }
 
+  /**
+   * Delete a specific meetup record
+   *
+   * @param {*} req
+   * @param {*} res
+   */
   static async deleteMeetup(req, res) {
     // check for admin user
     if (!req.user.isAdmin) {

--- a/app/controllers/QuestionController.js
+++ b/app/controllers/QuestionController.js
@@ -85,6 +85,32 @@ class QuestionController {
   }
 
   /**
+   * Get total number of posted questions by user id
+   *
+   * @param {*} req
+   * @param {*} res
+   */
+  static async getQuestionByUserId(req, res) {
+    try {
+      const queryString = 'SELECT COUNT(*) FROM questions WHERE questions.createdby = $1';
+
+      const {
+        rows,
+      } = await db.query(queryString, [req.user.id]);
+
+      return res.status(200).json({
+        status: 200,
+        data: rows,
+      });
+    } catch (error) {
+      return res.status(400).json({
+        status: 400,
+        error: 'Something went wrong, try again',
+      });
+    }
+  }
+
+  /**
    *
    * Upvote a specific question record
    *

--- a/app/routes/api/index.js
+++ b/app/routes/api/index.js
@@ -21,6 +21,11 @@ router.post('/meetups/:meetupId/rsvps',
   validate.validateBody(schema.rsvps),
   MeetupController.meetupResponse);
 
+// GET all meetup RSVPS route /meetups/rsvps
+router.get('/meetups/rsvps',
+  Auth.verifyToken,
+  MeetupController.getAllRsvps);
+
 // POST meetup images route /meetups/meetupId/images
 router.post('/meetups/:meetupId/images',
   Auth.verifyToken,
@@ -49,6 +54,11 @@ router.post('/questions',
 router.get('/questions',
   QuestionController.getAllQuestion);
 
+// GET get question by user id route /questions/user
+router.get('/questions/user',
+  Auth.verifyToken,
+  QuestionController.getQuestionByUserId);
+
 // POST comment route /comments/
 router.post('/comments',
   Auth.verifyToken,
@@ -58,6 +68,11 @@ router.post('/comments',
 // GET get all comments route /comments
 router.get('/comments',
   CommentController.getAllComment);
+
+// GET get commented questions by user id route /comments/user
+router.get('/comments/user',
+  Auth.verifyToken,
+  CommentController.getCommentByUserId);
 
 // PATCH up vote specific meetup question
 router.patch('/questions/:questionId/upvote',

--- a/app/test/meetup_test.js
+++ b/app/test/meetup_test.js
@@ -75,6 +75,8 @@ describe('POST api/v1/auth/signup', () => {
         const {
           body,
         } = res;
+
+        defaultTokenUser = body.data[0].token;
         expect(body).to.be.an('object');
         expect(body.status).to.be.a('number');
         expect(body.status).to.be.equals(201);
@@ -181,9 +183,6 @@ describe('POST api/v1/auth/login', () => {
         const {
           body,
         } = res;
-
-        defaultTokenUser = body.data[0].token;
-
         expect(body).to.be.an('object');
         expect(body.status).to.be.a('number');
         expect(body.status).to.be.equals(200);
@@ -643,6 +642,24 @@ describe('GET /api/v1/questions', () => {
   });
 });
 
+describe('GET /api/v1/questions/user', () => {
+  it('Should return total number of question posted by a user', (done) => {
+    chai.request(app)
+      .get('/api/v1/questions/user')
+      .set('token', adminToken)
+      .end((err, res) => {
+        const {
+          body,
+        } = res;
+        expect(body).to.be.an('object');
+        expect(body.status).to.be.a('number');
+        expect(body.status).to.be.equal(200);
+        expect(body).to.haveOwnProperty('data');
+        done();
+      });
+  });
+});
+
 describe('POST /api/v1/comments', () => {
   it('Should return an error if question record not found', (done) => {
     chai.request(app)
@@ -700,6 +717,25 @@ describe('GET /api/v1/comments', () => {
         expect(body).to.be.an('object');
         expect(body.status).to.be.a('number');
         expect(body.message).to.be.equal('These are users comments');
+        expect(body.status).to.be.equal(200);
+        expect(body).to.haveOwnProperty('data');
+        done();
+      });
+  });
+});
+
+
+describe('GET /api/v1/comments/user', () => {
+  it('Should return total number of commented question by a user', (done) => {
+    chai.request(app)
+      .get('/api/v1/comments/user')
+      .set('token', adminToken)
+      .end((err, res) => {
+        const {
+          body,
+        } = res;
+        expect(body).to.be.an('object');
+        expect(body.status).to.be.a('number');
         expect(body.status).to.be.equal(200);
         expect(body).to.haveOwnProperty('data');
         done();
@@ -832,9 +868,9 @@ describe('POST  /api/v1/meetups/:meetup_id/rsvps (valid)', () => {
   it('Should create new meet up rsvp record', (done) => {
     chai
       .request(app)
-      .post('/api/v1/meetups/2/rsvps')
+      .post('/api/v1/meetups/200/rsvps')
       .set('token', defaultTokenUser)
-      .send({ response: 'yes' })
+      .send({ response: 'No' })
       .end((err, res) => {
         const {
           body,
@@ -867,6 +903,69 @@ describe('POST  /api/v1/meetups/:meetup_id/rsvps (inValid)', () => {
         expect(body.status).to.be.equal(400);
         expect(body).to.haveOwnProperty('error');
         expect(body.error).to.be.an('array');
+        done();
+      });
+  });
+});
+
+
+// GET Test for valid request GET /api/v1/meetups/rsvps
+describe('GET /api/v1/meetups/rsvps (Invalid)', () => {
+  it('Should return error if user is not logged in', (done) => {
+    chai
+      .request(app)
+      .get('/api/v1/meetups/rsvps')
+      .set('token', '')
+      .end((err, res) => {
+        const {
+          body,
+        } = res;
+        expect(body).to.be.an('object');
+        expect(body.status).to.be.a('number');
+        expect(body.status).to.be.equal(403);
+        expect(body).to.haveOwnProperty('error');
+        expect(body.error).to.be.equal('Unauthorized!, you have to login');
+        done();
+      });
+  });
+});
+
+// GET Test for valid request GET /api/v1/meetups/rsvps
+describe('GET  /api/v1/meetups/rsvps (valid)', () => {
+  it('Should return user scheduled upcoming meetups', (done) => {
+    chai
+      .request(app)
+      .get('/api/v1/meetups/rsvps')
+      .set('token', adminToken)
+      .end((err, res) => {
+        const {
+          body,
+        } = res;
+        expect(body).to.be.an('object');
+        expect(body.status).to.be.a('number');
+        expect(body.status).to.be.equal(200);
+        expect(body).to.haveOwnProperty('data');
+        expect(body.data).to.be.an('array');
+        done();
+      });
+  });
+});
+
+// POST Test for valid request POST /api/v1/meetups/:meetups_id/rsvps
+describe('GET /api/v1/meetups/rsvps (no record found)', () => {
+  it('Should return Not found message no users scheduled upcoming record found', (done) => {
+    chai
+      .request(app)
+      .get('/api/v1/meetups/rsvps')
+      .set('token', defaultTokenUser)
+      .end((err, res) => {
+        const {
+          body,
+        } = res;
+        expect(body).to.be.an('object');
+        expect(body.status).to.be.a('number');
+        expect(body.status).to.be.equal(404);
+        expect(body).to.haveOwnProperty('error');
         done();
       });
   });


### PR DESCRIPTION
### What does this PR do?

Allow a user to see all activity within the questioner app after a successful login by showing total posted questions, total commented questions and their scheduled upcoming meetup.

### Description of the task to be completed?

   * Have the following listed task completed

      - connect user dashboard front-end page with the listed API endpoints below:

     `/api/v1/meetups/rsvps to get all user scheduled meetup`

     `/api/v1/questions/user to get total user posted questions`

     `/api/v1/comments/user to get total user commented questions`

### How should this be tested manually?
  * By visiting the link listed below

     [Meetup-questioner-app](https://abidex4yemi.github.io/meet-up-questioner/sign-in.html)

### What are the relevant pivotal tracker stories?

<a href='https://www.pivotaltracker.com/story/show/163730056'>#163730056</a>
<a href='https://www.pivotaltracker.com/story/show/163742231'>#163742231</a>
<a href='https://www.pivotaltracker.com/story/show/163751741'>#163751741</a>
![user-dashboard-1](https://user-images.githubusercontent.com/23571838/52341400-b79fec80-2a12-11e9-9cfb-9ba4a95bc15a.JPG)
